### PR TITLE
Corrige une erreur dans un exemple de requête

### DIFF
--- a/src/reference/ressources/inscription/parcours.md
+++ b/src/reference/ressources/inscription/parcours.md
@@ -32,7 +32,7 @@ curl https://myapi.aimaira.net/GraphV1/Parcours/2215168
 ::: code-group
 
 ```bash [cURL]
-curl https://myapi.aimaira.net/GraphV1/Parcours/2215168?$expand=ParcoursPeriode
+curl https://myapi.aimaira.net/GraphV1/Parcours/2215168?$expand=ParcoursPeriodes
     -u 'nomdutilisateur:motdepasse'
 ```
 


### PR DESCRIPTION
Corrige une erreur dans l'exemple de requête permettant de lister les parcours liés à une période

Merci à Christophe de l'ISEP