### PR TITLE
Corrige le lien manquant du menu Enseignant

### DIFF
--- a/src/.vitepress/nav.ts
+++ b/src/.vitepress/nav.ts
@@ -107,6 +107,7 @@ const nav = [
                         items: [
                             {
                                 text: 'Enseignant',
+                                link: '/reference/ressources/academie/enseignant'
                             }
                         ]
                     },


### PR DESCRIPTION
Ajoute le lien vers /reference/ressources/academie/enseignant qui manquait dans l'entrée du menu Enseignant.